### PR TITLE
Added HasuraApiError with human-friendly `message`

### DIFF
--- a/src/errors.js
+++ b/src/errors.js
@@ -1,0 +1,17 @@
+const capitalize = string => string[0].toUpperCase() + string.slice(1);
+const withPeriod = string => string.slice(-1)[0] === '.' ? string : `${string}.`;
+const humanizeErrorCode = input => input.split('-').map(capitalize).join(' ');
+const humanizeErrorMessage = input => capitalize(withPeriod(input.trim()));
+
+export class HasuraApiError extends Error {
+  constructor(response) {
+    super();
+    this.name = 'HasuraApiError';
+    this.code = response.code;
+    // This message will be displayed to the user in a Notification
+    this.message = [
+      response.code && humanizeErrorCode(response.code),
+      response.error && humanizeErrorMessage(response.error)
+    ].filter(Boolean).join(': ');
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,9 @@ import {
   updateQuery,
   deleteQuery
 } from './queries';
+import {HasuraApiError} from './errors';
+
+export {HasuraApiError};
 
 const DEFAULT_PRIMARY_KEY = 'id';
 
@@ -204,7 +207,7 @@ export default (serverEndpoint, httpClient, config) => {
   const convertHTTPResponse = (response, type, resource, params) => {
     // handle errors and throw with the message
     if ('error' in response || 'code' in response) {
-      throw new Error(JSON.stringify(response));
+      throw new HasuraApiError(response);
     }
     const primaryKey = getPrimaryKey(resource);
 


### PR DESCRIPTION
With this change, end-users will get nice, pretty. human-readable error messages by default, without the developer needing to mutate/monkey-patch error objects inside `authProvider.checkError(error)`.

Example message displayed to end-user:

Before:
{"code":"permission-denied","error":"role \\"user\\" does not have permission to update column \\"roleId\\""}

After: 
Permission Denied: Role "user" does not have permission to update column "roleId".