### PR TITLE
Fix typo in Usage example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ const App = () => {
 
   useEffect(() => {
     const buildDataProvider = async () => {
-      const dataProvider = await buildHasuraProvider(
-        (clientOptions: { uri: 'http://localhost:8080/v1/graphql' })
-      );
+      const dataProvider = await buildHasuraProvider({
+        clientOptions: { uri: 'http://localhost:8080/v1/graphql' },
+      });
       setDataProvider(() => dataProvider);
     };
     buildDataProvider();


### PR DESCRIPTION
Fix syntax when passing options argument to `buildHasuraProvider`