### PR TITLE
Fix issue when sanitizing a null value in an array

### DIFF
--- a/src/getResponseParser.js
+++ b/src/getResponseParser.js
@@ -22,7 +22,7 @@ const sanitizeResource = (data = {}) => {
       return acc;
     }
     if (Array.isArray(dataKey)) {
-      if (typeof dataKey[0] === 'object') {
+      if (dataKey[0] && typeof dataKey[0] === 'object') {
         // if var is an array of reference objects with id properties
         if (dataKey[0].id != null) {
           return {


### PR DESCRIPTION
The sanitize function was failing with `cannot read 'id' of null` when sanitizing a nested JSON field that contained the array `[ null ]`