### PR TITLE
Add option for custom aggregate field name

### DIFF
--- a/src/buildGqlQuery.js
+++ b/src/buildGqlQuery.js
@@ -37,7 +37,6 @@ export const buildFields = (type) =>
   type.fields.reduce((acc, field) => {
     const type = getFinalType(field.type);
 
-
     if (type.kind !== TypeKind.OBJECT && type.kind !== TypeKind.INTERFACE) {
       return [...acc, gqlTypes.field(gqlTypes.name(field.name))];
     }
@@ -158,7 +157,8 @@ export const buildGqlQuery = (
   buildFields,
   buildMetaArgs,
   buildArgs,
-  buildApolloArgs
+  buildApolloArgs,
+  aggregateFieldName
 ) => (resource, aorFetchType, queryType, variables) => {
   const { sortField, sortOrder, ...metaVariables } = variables;
   const apolloArgs = buildApolloArgs(queryType, variables);
@@ -182,7 +182,7 @@ export const buildGqlQuery = (
             gqlTypes.selectionSet(fields)
           ),
           gqlTypes.field(
-            gqlTypes.name(`${queryType.name}_aggregate`),
+            gqlTypes.name(aggregateFieldName(queryType.name)),
             gqlTypes.name('total'),
             metaArgs,
             null,

--- a/src/buildVariables.js
+++ b/src/buildVariables.js
@@ -65,7 +65,7 @@ const buildGetListVariables = (introspectionResults) => (
     } else {
       let [keyName, operation = ''] = key.split('@');
       const field = resource.type.fields.find((f) => f.name === keyName);
-      if (field ) {
+      if (field) {
         switch (getFinalType(field.type).name) {
           case 'String':
             operation = operation || '_ilike';
@@ -84,14 +84,12 @@ const buildGetListVariables = (introspectionResults) => (
     }
     return [...acc, filter];
   };
-  const andFilters = Object.keys(filterObj).reduce(
-    filterReducer(filterObj),
-    customFilters
-  ).filter(Boolean);
-  const orFilters = Object.keys(orFilterObj).reduce(
-    filterReducer(orFilterObj),
-    []
-  ).filter(Boolean);
+  const andFilters = Object.keys(filterObj)
+    .reduce(filterReducer(filterObj), customFilters)
+    .filter(Boolean);
+  const orFilters = Object.keys(orFilterObj)
+    .reduce(filterReducer(orFilterObj), [])
+    .filter(Boolean);
 
   result['where'] = {
     _and: andFilters,

--- a/src/index.js
+++ b/src/index.js
@@ -32,7 +32,7 @@ export {
   defaultGetResponseParser,
 };
 import buildQuery from './buildQuery';
-import buildVariables from './buildVariables'
+import buildVariables from './buildVariables';
 
 export { buildQuery, buildGqlQuery, buildVariables };
 
@@ -57,6 +57,7 @@ const buildGqlQueryDefaults = {
   buildMetaArgs,
   buildArgs,
   buildApolloArgs,
+  aggregateFieldName: (resourceName) => `${resourceName}_aggregate`,
 };
 
 const buildCustomDataProvider = (
@@ -76,7 +77,8 @@ const buildCustomDataProvider = (
       buildGqlQueryOptions.buildFields,
       buildGqlQueryOptions.buildMetaArgs,
       buildGqlQueryOptions.buildArgs,
-      buildGqlQueryOptions.buildApolloArgs
+      buildGqlQueryOptions.buildApolloArgs,
+      buildGqlQueryOptions.aggregateFieldName
     );
 
   const buildQuery = buildQueryFactory(


### PR DESCRIPTION
In Hasura it's possible to customise the aggregate field name, but
currently this package will break with anything other than the default
aggregate name.

This PR adds an option to change this via a function, defaulting to the
existing functionality of `resource_aggregate`.