### PR TITLE
Feat: UPDATE only permitted fields

### DIFF
--- a/src/buildVariables.js
+++ b/src/buildVariables.js
@@ -194,9 +194,15 @@ const buildUpdateVariables = (introspectionResults) => (
     let permitted_fields = null;
     const resource_name = resource.type.name;
     if (resource_name) {
-      permitted_fields = introspectionResults.types
-        .find((obj) => obj.name === `${resource_name}_set_input`)
-        ?.inputFields?.map((obj) => obj.name);
+      let inputType = introspectionResults.types.find(
+        (obj) => obj.name === `${resource_name}_set_input`
+      );
+      if (inputType) {
+        let inputTypeFields = inputType.inputFields;
+        if (inputTypeFields) {
+          permitted_fields = inputTypeFields.map((obj) => obj.name);
+        }
+      }
     }
   return Object.keys(params.data).reduce((acc, key) => {
     // If hasura permissions do not allow a field to be updated like (id),
@@ -204,9 +210,8 @@ const buildUpdateVariables = (introspectionResults) => (
     // RA passes the whole previous Object here
     // https://github.com/marmelab/react-admin/issues/2414#issuecomment-428945402
 
-    // TODO: To overcome this permission issue,
-    // it would be better to allow only permitted inputFields from *_set_input INPUT_OBJECT
-    // @^
+    // Fetch permitted fields from *_set_input INPUT_OBJECT and filter out any key 
+    // not present inside it    
     if (permitted_fields && !permitted_fields.includes(key)) return acc;
 
     if (params.previousData && params.data[key] === params.previousData[key]) {

--- a/src/buildVariables.js
+++ b/src/buildVariables.js
@@ -191,6 +191,13 @@ const buildUpdateVariables = (introspectionResults) => (
     resource,
     params
   );
+    let permitted_fields = null;
+    const resource_name = resource.type.name;
+    if (resource_name) {
+      permitted_fields = introspectionResults.types
+        .find((obj) => obj.name === `${resource_name}_set_input`)
+        ?.inputFields?.map((obj) => obj.name);
+    }
   return Object.keys(params.data).reduce((acc, key) => {
     // If hasura permissions do not allow a field to be updated like (id),
     // we are not allowed to put it inside the variables
@@ -199,6 +206,9 @@ const buildUpdateVariables = (introspectionResults) => (
 
     // TODO: To overcome this permission issue,
     // it would be better to allow only permitted inputFields from *_set_input INPUT_OBJECT
+    // @^
+    if (permitted_fields && !permitted_fields.includes(key)) return acc;
+
     if (params.previousData && params.data[key] === params.previousData[key]) {
       return acc;
     }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,3 @@
-  
 const path = require('path');
 
 module.exports = {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,11 +14,12 @@ module.exports = {
         test: /\.js?$/,
         exclude: /(node_modules)/,
         use: {
-           loader: 'babel-loader',
-           options: {
-           presets: [
-            ['@babel/preset-env', { targets: "defaults" }]
-          ]
+          loader: 'babel-loader',
+          options: {
+            presets: [
+              ['@babel/preset-env', { targets: "defaults" }]
+            ]
+          }
         }
       },
       {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,4 @@
+  
 const path = require('path');
 
 module.exports = {
@@ -13,14 +14,7 @@ module.exports = {
       {
         test: /\.js?$/,
         exclude: /(node_modules)/,
-        use: {
-          loader: 'babel-loader',
-          options: {
-            presets: [
-              ['@babel/preset-env', { targets: "defaults" }]
-            ]
-          }
-        }
+        use: 'babel-loader',
       },
       {
         test: /\.mjs$/,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,7 +13,13 @@ module.exports = {
       {
         test: /\.js?$/,
         exclude: /(node_modules)/,
-        use: 'babel-loader',
+        use: {
+           loader: 'babel-loader',
+           options: {
+           presets: [
+            ['@babel/preset-env', { targets: "defaults" }]
+          ]
+        }
       },
       {
         test: /\.mjs$/,


### PR DESCRIPTION
### Update only permitted fields for each role
---
- A `_set` value with fields that were outside of the permission scope of the user role was causing the update mutation to fail.

- Fixed by first creating a list of `permitted_fields` from the `introspectionResults` and then matching every `key` in the RA `params.data` object against that list.

@praveenweb: 
- ##### Fixes a `//TODO` 
- Please review! Thanks :)

