### PR TITLE
fix #75 nested keys with array values

### DIFF
--- a/src/buildVariables.js
+++ b/src/buildVariables.js
@@ -80,7 +80,7 @@ const buildGetListVariables = (introspectionResults) => (
     if (key === 'ids') {
       filter = { id: { _in: obj['ids'] } };
     } else if (Array.isArray(obj[key])) {
-      filter = { [key]: { _in: obj[key] } };
+      filter = set({}, key.split(SPLIT_TOKEN), { _in: obj[key] });
     } else if (obj[key] && obj[key].format === 'hasura-raw-query') {
       filter = { [key]: obj[key].value || {} };
     } else {


### PR DESCRIPTION
given

`filter: {"table1#table2":["value1"]}`

expected a query `where`

`where: {"table1":{"table2":{_in:["value1"]}}}`

not `where: {"table1#table2":{_in:["value1"]}}`