### PR TITLE
fix: json column key start with an underscore is missing

### DIFF
--- a/src/getResponseParser/sanitizeResource.test.ts
+++ b/src/getResponseParser/sanitizeResource.test.ts
@@ -12,4 +12,29 @@ describe('sanitizeResource', () => {
       '1': { name: 'brand', value: null },
     });
   });
+
+  it('Should skip key with two underscores', () => {
+    expect(
+      sanitizeResource([
+        {
+          name: 'vendor',
+          value: 'Test Vendor',
+          metadata: {
+            _key: 'value',
+            fields: [{ _type: 'string', name: 'title' }],
+          },
+          __typename: 'name',
+        },
+      ])
+    ).toEqual({
+      '0': {
+        name: 'vendor',
+        value: 'Test Vendor',
+        metadata: {
+          _key: 'value',
+          fields: [{ _type: 'string', name: 'title' }],
+        },
+      },
+    });
+  });
 });

--- a/src/getResponseParser/sanitizeResource.ts
+++ b/src/getResponseParser/sanitizeResource.ts
@@ -1,6 +1,7 @@
 export const sanitizeResource = (data: any = {}): object => {
   const result = Object.keys(data).reduce((acc, key) => {
-    if (key.startsWith('_')) {
+    // intend to remove the following reserved names https://spec.graphql.org/draft/#sec-Names.Reserved-Names
+    if (key.startsWith('__')) {
       return acc;
     }
 


### PR DESCRIPTION
https://github.com/hasura/ra-data-hasura/blob/master/src/getResponseParser/sanitizeResource.ts#L3

As I understand this line will skip [GraphQL reserved names](https://spec.graphql.org/draft/#sec-Names.Reserved-Names) but the reserved name starts with two underscores.

So it affects to JSON column that contains key field which starts with an underscore

image1
![Screen Shot 2022-07-12 at 12 14 47](https://user-images.githubusercontent.com/5567955/178415505-3e0c7ba8-909b-4dd6-9a7b-c0a2473aa0de.png)

image2
![Screen Shot 2022-07-12 at 12 16 12](https://user-images.githubusercontent.com/5567955/178415511-d3bbae73-0561-4f80-9d86-b6fc573e5966.png)

image3
![Screen Shot 2022-07-12 at 12 17 12](https://user-images.githubusercontent.com/5567955/178415520-1c6a5d91-e6de-4cd5-8ba3-2868e07e8c3c.png)


