### PR TITLE
support skipping count aggregate on hasura

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ra-data-hasura",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ra-data-hasura",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "license": "MIT",
       "dependencies": {
         "graphql": "^15.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ra-data-hasura",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "A data provider for connecting react-admin to a Hasura endpoint",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/buildGqlQuery/index.ts
+++ b/src/buildGqlQuery/index.ts
@@ -59,7 +59,7 @@ export const buildGqlQuery: BuildGqlQuery =
       aorFetchType === GET_MANY ||
       aorFetchType === GET_MANY_REFERENCE
     ) {
-      let gQlArray = [
+      let gqlArray = [
         gqlTypes.field(
           gqlTypes.name(queryType.name),
           gqlTypes.name('items'),
@@ -71,7 +71,7 @@ export const buildGqlQuery: BuildGqlQuery =
       // Skip aggregate calls when provided aggregateFieldName function returns NO_COUNT.
       // This is useful to avoid expensive count queries.
       if (aggregateFieldName(queryType.name) !== 'NO_COUNT') {
-        gQlArray.push(
+        gqlArray.push(
           gqlTypes.field(
             gqlTypes.name(aggregateFieldName(queryType.name)),
             gqlTypes.name('total'),
@@ -92,7 +92,7 @@ export const buildGqlQuery: BuildGqlQuery =
       return gqlTypes.document([
         gqlTypes.operationDefinition(
           'query',
-          gqlTypes.selectionSet(gQlArray),
+          gqlTypes.selectionSet(gqlArray),
           gqlTypes.name(queryType.name),
           apolloArgs
         ),

--- a/src/buildGqlQuery/index.ts
+++ b/src/buildGqlQuery/index.ts
@@ -59,35 +59,38 @@ export const buildGqlQuery: BuildGqlQuery =
       aorFetchType === GET_MANY ||
       aorFetchType === GET_MANY_REFERENCE
     ) {
+      let gQlArray = [
+        gqlTypes.field(
+          gqlTypes.name(queryType.name),
+          gqlTypes.name('items'),
+          args,
+          null,
+          gqlTypes.selectionSet(fields)
+        ),
+      ];
+      if (aggregateFieldName(queryType.name) !== 'NO_COUNT') {
+        gQlArray.push(
+          gqlTypes.field(
+            gqlTypes.name(aggregateFieldName(queryType.name)),
+            gqlTypes.name('total'),
+            metaArgs,
+            null,
+            gqlTypes.selectionSet([
+              gqlTypes.field(
+                gqlTypes.name('aggregate'),
+                null,
+                null,
+                null,
+                gqlTypes.selectionSet([gqlTypes.field(gqlTypes.name('count'))])
+              ),
+            ])
+          )
+        );
+      }
       return gqlTypes.document([
         gqlTypes.operationDefinition(
           'query',
-          gqlTypes.selectionSet([
-            gqlTypes.field(
-              gqlTypes.name(queryType.name),
-              gqlTypes.name('items'),
-              args,
-              null,
-              gqlTypes.selectionSet(fields)
-            ),
-            gqlTypes.field(
-              gqlTypes.name(aggregateFieldName(queryType.name)),
-              gqlTypes.name('total'),
-              metaArgs,
-              null,
-              gqlTypes.selectionSet([
-                gqlTypes.field(
-                  gqlTypes.name('aggregate'),
-                  null,
-                  null,
-                  null,
-                  gqlTypes.selectionSet([
-                    gqlTypes.field(gqlTypes.name('count')),
-                  ])
-                ),
-              ])
-            ),
-          ]),
+          gqlTypes.selectionSet(gQlArray),
           gqlTypes.name(queryType.name),
           apolloArgs
         ),

--- a/src/buildGqlQuery/index.ts
+++ b/src/buildGqlQuery/index.ts
@@ -68,6 +68,8 @@ export const buildGqlQuery: BuildGqlQuery =
           gqlTypes.selectionSet(fields)
         ),
       ];
+      // Skip aggregate calls when provided aggregateFieldName function returns NO_COUNT.
+      // This is useful to avoid expensive count queries.
       if (aggregateFieldName(queryType.name) !== 'NO_COUNT') {
         gQlArray.push(
           gqlTypes.field(

--- a/src/buildQuery/index.ts
+++ b/src/buildQuery/index.ts
@@ -3,6 +3,15 @@ import buildGqlQuery, { BuildGqlQueryFactory } from '../buildGqlQuery';
 import { getResponseParser, GetResponseParser } from '../getResponseParser';
 import type { FetchType, IntrospectionResult } from '../types';
 
+export type QueryResponse = {
+  data: any;
+  total?: number;
+  pageInfo?: {
+    hasNextPage?: boolean;
+    hasPreviousPage?: boolean;
+  };
+};
+
 export type BuildQuery = (introspectionResults: IntrospectionResult) => (
   aorFetchType: FetchType,
   resourceName: string,
@@ -10,7 +19,7 @@ export type BuildQuery = (introspectionResults: IntrospectionResult) => (
 ) => {
   query: any;
   variables: any;
-  parseResponse: ({ data }: any) => { data: any; total?: number };
+  parseResponse: ({ data }: any) => QueryResponse;
 };
 
 export type BuildQueryFactory = (

--- a/src/getResponseParser/index.ts
+++ b/src/getResponseParser/index.ts
@@ -33,6 +33,7 @@ export const getResponseParser: GetResponseParser =
         if (typeof response.total !== 'undefined') {
           output.total = response.total.aggregate.count;
         } else {
+          // TODO: behave smarter and set hasNextPage=false when no more records exist.
           output.pageInfo = {
             hasPreviousPage: true,
             hasNextPage: true,


### PR DESCRIPTION
issue: https://github.com/hasura/ra-data-hasura/issues/117

current hasura graphql provider always make an aggregate count call
```
tota: table(
    order_by: $order_by
    where: $where
  ) {
    aggregate {
      count
      __typename
    }
```

which is very expensive on most RDMS like postgres.

this PR introduces a very simple workaround. when caller providers 
`aggregateFieldName(resource) = NO_COUNT` we simply skip count call and provide [partial pagination](https://marmelab.com/react-admin/DataProviderWriting.html#partial-pagination) instead.


This is a NO-OP unless caller provide custom aggregateFiledName function.

### TEST

called sample app with and without 
```
aggregateFieldName: (_) => "NO_COUNT"
```

and verified the behavior.