### PR TITLE
added support for empty operator in buildGetListVariables

### DIFF
--- a/src/buildVariables/buildGetListVariables.ts
+++ b/src/buildVariables/buildGetListVariables.ts
@@ -90,37 +90,39 @@ export const buildGetListVariables: BuildGetListVariables =
       } else {
         let [keyName, operation = ''] = key.split(SPLIT_OPERATION);
         let operator;
+        if (operation === '{}') operator = {};
         const field = resource.type.fields.find((f) => f.name === keyName);
         if (field) {
           switch (getFinalType(field.type).name) {
             case 'String':
               operation = operation || '_ilike';
-              operator = {
-                [operation]: operation.includes('like')
-                  ? `%${obj[key]}%`
-                  : obj[key],
-              };
+              if (!operator)
+                operator = {
+                  [operation]: operation.includes('like')
+                    ? `%${obj[key]}%`
+                    : obj[key],
+                };
               filter = set({}, keyName.split(SPLIT_TOKEN), operator);
               break;
             default:
-              operator = {
-                [operation]: operation.includes('like')
-                  ? `%${obj[key]}%`
-                  : obj[key],
-              };
-              filter = set({}, keyName.split(SPLIT_TOKEN), {
-                [operation || '_eq']: obj[key],
-              });
+              if (!operator)
+                operator = {
+                  [operation || '_eq']: operation.includes('like')
+                    ? `%${obj[key]}%`
+                    : obj[key],
+                };
+              filter = set({}, keyName.split(SPLIT_TOKEN), operator);
           }
         } else {
           // Else block runs when the field is not found in Graphql schema.
           // Most likely it's nested. If it's not, it's better to let
           // Hasura fail with a message than silently fail/ignore it
-          operator = {
-            [operation || '_eq']: operation.includes('like')
-              ? `%${obj[key]}%`
-              : obj[key],
-          };
+          if (!operator)
+            operator = {
+              [operation || '_eq']: operation.includes('like')
+                ? `%${obj[key]}%`
+                : obj[key],
+            };
           filter = set({}, keyName.split(SPLIT_TOKEN), operator);
         }
       }


### PR DESCRIPTION
I had a case where I needed a filter that will list all orders without a review. According to Hasura docs, that's how it should be done: https://hasura.io/docs/latest/queries/postgres/query-filters/#fetch-if-nested-objects-existdo-not-exist

I was unable to do so with the current conditions in `buildGetListVariables.ts`. I added a condition that allows `{}` as an operation. It generates an empty operator instead of a default `_eq`.

It allowed me to write a filter with `source="_not#review@{}"` that generates this kind of query:

```gql
query OrdersWithoutReviews {
  orders(where: {_and: [{_not: {review: {}}}]}) {
    review {
      id
    }
  }
}
```