### PR TITLE
fix: hasura-raw-query to support nested filtering

### DIFF
--- a/src/buildVariables/buildGetListVariables.ts
+++ b/src/buildVariables/buildGetListVariables.ts
@@ -94,7 +94,7 @@ export const buildGetListVariables: BuildGetListVariables =
           : obj[key];
         filter = set({}, keyName.split(SPLIT_TOKEN), { [operation]: value });
       } else if (obj[key] && obj[key].format === 'hasura-raw-query') {
-        filter = { [key]: obj[key].value || {} };
+        filter = set({}, key.split(SPLIT_TOKEN), obj[key].value || {});
       } else {
         let [keyName, operation = ''] = key.split(SPLIT_OPERATION);
         let operator;
@@ -184,7 +184,7 @@ export const buildGetListVariables: BuildGetListVariables =
     }
 
     if (distinct_on) {
-      result["distinct_on"] = distinct_on;
+      result['distinct_on'] = distinct_on;
     }
 
     return result;


### PR DESCRIPTION
`hasura-raw-query` doesn't support nested filtering using # as a field separator
Ref: https://github.com/hasura/ra-data-hasura#nested-filtering

raw query
```typescript
{
  "transfer#date": {
    "format": "hasura-raw-query",
    "value": {
      "_gte": "2022-02-02",
      "_lte": "2022-03-03"
    }
  }
}
```

problem result
```typescript
{
  "transfer#date": {
    "_gte": "2022-02-02",
    "_lte": "2022-03-03"
  }
}
```

should be
```typescript
{
  "transfer": {
    "date": {
      "_gte": "2022-02-02",
      "_lte": "2022-03-03"
    }
  }
}
```