### PR TITLE
add sort ability to support nulls_first and nulls_last

### DIFF
--- a/src/buildVariables/buildGetListVariables.ts
+++ b/src/buildVariables/buildGetListVariables.ts
@@ -175,17 +175,40 @@ export const buildGetListVariables: BuildGetListVariables =
         }
 
         const multiSort = fields.map((field: any, index: number) =>
-          set({}, field, orders[index])
+          makeSort(field, orders[index])
         );
         result['order_by'] = multiSort;
       } else {
-        result['order_by'] = set({}, field, order.toLowerCase());
+        result['order_by'] = makeSort(field, order);
       }
     }
 
     if (distinct_on) {
-      result["distinct_on"] = distinct_on;
+      result['distinct_on'] = distinct_on;
     }
 
     return result;
   };
+
+/**
+ * if the field contains a SPLIT_OPERATION, it means it's column ordering option.
+ *
+ * @example
+ * ```
+ * makeSort('title', 'ASC') => { title: 'asc' }
+ * ```
+ * @example
+ * ```
+ * makeSort('title@nulls_last', 'ASC') => { title: 'asc_nulls_last' }
+ * ```
+ * @example
+ * ```
+ * makeSort('title@nulls_first', 'ASC') => { title: 'asc_nulls_first' }
+ * ```
+ *
+ */
+const makeSort = (field: string, sort: 'ASC' | 'DESC') => {
+  const [fieldName, operation] = field.split(SPLIT_OPERATION);
+  const fieldSort = operation ? `${sort}_${operation}` : sort;
+  return set({}, fieldName, fieldSort.toLowerCase());
+};


### PR DESCRIPTION
I use `@` as a operation separator from field name (the same as filter but for sort)

# Example

## List default sort field
```jsx
const TodoList = (props) => (
  <List sort={{ field: 'title@nulls_last,is_completed', order: 'asc,desc' }} {...props}>
    <Datagrid rowClick="edit">...</Datagrid>
  </List>
);
```

will generate a query with an `order_by`:

```
order_by: [{ title: "asc_nulls_last" }, { is_completed: "desc" }]
```

## Field sortBy

```jsx
const TodoList = (props) => (
  <List {...props}>
    <Datagrid>
        <TextField source="title" sortBy="title@nulls_last" />
    </Datagrid>
  </List>
);
```

will generate a query with an `order_by`:

```
order_by: [{ title: "asc_nulls_last" }]
```