### PR TITLE
properly parse array in sanitize function

### DIFF
--- a/src/getResponseParser/sanitizeResource.test.ts
+++ b/src/getResponseParser/sanitizeResource.test.ts
@@ -1,16 +1,52 @@
 import { sanitizeResource } from './sanitizeResource';
 
 describe('sanitizeResource', () => {
+  it('should properly parse array values at any depth', () => {
+    expect(sanitizeResource([0, 1, 2, 3])).toEqual([0, 1, 2, 3]);
+    expect(sanitizeResource([[0, 1, 2, 3]])).toEqual([[0, 1, 2, 3]]);
+    expect(sanitizeResource({ data: [[0, 1, 2, 3]] })).toEqual({
+      data: [[0, 1, 2, 3]],
+    });
+  });
+
+  it('should add keyIds for arrays of objects with id', () => {
+    expect(
+      sanitizeResource({
+        testValue: [
+          { id: 1, name: 'Test 1' },
+          { id: 2, name: 'Test 2' },
+        ],
+      })
+    ).toEqual({
+      testValue: [
+        { id: 1, name: 'Test 1' },
+        { id: 2, name: 'Test 2' },
+      ],
+      testValueIds: [1, 2],
+    });
+  });
+
+  it('should add key.id value for objects with id', () => {
+    expect(
+      sanitizeResource({
+        testValue: { id: 1, name: 'Test 1' },
+      })
+    ).toEqual({
+      testValue: { id: 1, name: 'Test 1' },
+      'testValue.id': 1,
+    });
+  });
+
   it('It keeps null values', () => {
     expect(
       sanitizeResource([
         { name: 'vendor', value: 'Test Vendor' },
         { name: 'brand', value: null },
       ])
-    ).toEqual({
-      '0': { name: 'vendor', value: 'Test Vendor' },
-      '1': { name: 'brand', value: null },
-    });
+    ).toEqual([
+      { name: 'vendor', value: 'Test Vendor' },
+      { name: 'brand', value: null },
+    ]);
   });
 
   it('Should skip key with two underscores', () => {
@@ -26,8 +62,8 @@ describe('sanitizeResource', () => {
           __typename: 'name',
         },
       ])
-    ).toEqual({
-      '0': {
+    ).toEqual([
+      {
         name: 'vendor',
         value: 'Test Vendor',
         metadata: {
@@ -35,6 +71,6 @@ describe('sanitizeResource', () => {
           fields: [{ _type: 'string', name: 'title' }],
         },
       },
-    });
+    ]);
   });
 });


### PR DESCRIPTION
proposition of fix for https://github.com/hasura/ra-data-hasura/issues/156

I've also simplified a bit the sanitizeResource function and added some tests.

Note that this change should be considered major in versionning since it breaks backward compatibility.

before:
```
sanitizeResource([0, 1, 2]) == { 0: 0, 1: 1, 2: 2}
```

after:
```
sanitizeResource([0, 1, 2]) == [0, 1 ,2]
```