### PR TITLE
fix: prevent defeinitions/init from being removed by tree-shaking

### DIFF
--- a/src/graphql-ast-types-browser/index.js
+++ b/src/graphql-ast-types-browser/index.js
@@ -22,7 +22,8 @@ exports.is = is;
 exports.isType = isType;
 exports.validate = validate;
 exports.shallowEqual = shallowEqual;
-require('./definitions/init');
+
+var _require = require('./definitions/init');
 
 var _require = require('./definitions'),
   ALIAS_KEYS = _require.ALIAS_KEYS,


### PR DESCRIPTION
This fix #173 for me, but I'm not sure if it may cause other issues